### PR TITLE
Extend role to provide more functionality and more platforms

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,10 @@
 ---
-puppet_package_name: puppet
+puppet_package_list:
+  - puppet
+  - facter
+puppet_release_package_state: present
+puppet_release_rpm_baseurl: http://yum.puppetlabs.com
+puppet_release_apt_baseurl: http://apt.puppetlabs.com
+puppet_package_state: present
+puppet_master: puppet
+puppet_environment:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ puppet_release_apt_baseurl: http://apt.puppetlabs.com
 puppet_package_state: present
 puppet_master: puppet
 puppet_environment:
+puppet_waitforcert: 60

--- a/hosts
+++ b/hosts
@@ -1,0 +1,1 @@
+localhost

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,14 +1,23 @@
 ---
 galaxy_info:
   author: Vlatko Kosturjak
-  description: Installs puppet on ubuntu
+  description: Install and initialize puppet agent on debian and fedora derivates
   company: kost
   license: BSD
   min_ansible_version: 1.5
   platforms:
+  - name: Debian
+    versions:
+    - all
   - name: Ubuntu
     versions:
-    - trusty
+    - all
+  - name: EL
+    versions:
+    - all
+  - name: Fedora
+    versions:
+    - all
   categories:
   - system
   - packaging

--- a/puppet.yml
+++ b/puppet.yml
@@ -1,0 +1,6 @@
+---
+- name : Puppet agent management
+  hosts : all
+  sudo : True
+  roles:
+    - puppet

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,51 @@
 ---
-- name: install puppet
-  sudo: yes
-  action: apt pkg="{{item}}" state=present update_cache=yes
-  with_items:
-      - "{{puppet_package_name}}"
-  tags: puppet
+---
+- name: Install PuppetLabs release RPM for Fedora or EL derivatives
+  yum:name="{{ item }}.noarch.rpm" state={{ puppet_release_package_state }}
+  with_item:
+    - "{{ puppet_release_rpm_baseurl }}/puppetlabs-release-{% if ansible_distribution == 'Fedora' %}fedora{% else %}el{% endif %}-{{ ansible_distribution_version.split('.')[0] }}"
+  when: ansible_os_family == 'RedHat'
+  tags:
+    - repo
+    - install
+    - packages
 
+- name: Install PuppetLabs release DEB for Debian derivates
+  template: src=repo.j2 dest=/etc/apt.sources.d/puppetlabs.source owner=root group=root mode=0644
+  apt: pkg=puppet state={{ item }} update_cache=yes
+  with_items:
+    - "{{ puppet_release_rpm_baseurl }}/puppetlabs-release-{{ ansible_distribution_release }}"
+  when: ansible_os_family == 'Debian'
+  tags:
+    - repo
+    - install
+    - packages
+
+- name: Install puppet via yum
+  yum: name={{ item }} state={{ puppet_package_state }}
+  with_items:
+    - {{ puppet_package_list }}
+  when: ansible_os_family == 'RedHat'
+  tags:
+    - install
+    - packages
+
+- name: Install puppet via apt
+  apt: pkg={{ item }} state={{ puppet_package_state }} update_cache=yes
+  with_items:
+    - {{ puppet_package_list }}
+  when: ansible_os_family == 'Debian'
+  tags:
+    - install
+    - packages
+
+- name: Enable puppet service
+  service: name=puppet enabled=yes state=started
+  tags:
+    - install
+    - service
+
+- name: Force run of puppet agent
+  command: /usr/bin/puppet agent apply --test --server={{ puppet_master }} --environment={{ puppet_environment }}
+  tags:
+    - run

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install PuppetLabs release RPM for Fedora or EL derivatives
-  yum:name="{{ item }}.noarch.rpm" state={{ puppet_release_package_state }}
+  yum: name="{{ item }}.noarch.rpm" state={{ puppet_release_package_state }}
   with_items:
     - "{{ puppet_release_rpm_baseurl }}/puppetlabs-release-{% if ansible_distribution == 'Fedora' %}fedora{% else %}el{% endif %}-{{ ansible_distribution_version.split('.')[0] }}"
   when: ansible_os_family == 'RedHat'
@@ -10,7 +10,6 @@
     - packages
 
 - name: Install PuppetLabs release DEB for Debian derivates
-  template: src=repo.j2 dest=/etc/apt.sources.d/puppetlabs.source owner=root group=root mode=0644
   apt: pkg=puppet state={{ item }} update_cache=yes
   with_items:
     - "{{ puppet_release_rpm_baseurl }}/puppetlabs-release-{{ ansible_distribution_release }}.deb"
@@ -23,7 +22,7 @@
 - name: Install puppet via yum
   yum: name={{ item }} state={{ puppet_package_state }}
   with_items:
-    - {{ puppet_package_list }}
+    - "{{ puppet_package_list }}"
   when: ansible_os_family == 'RedHat'
   tags:
     - install
@@ -32,7 +31,7 @@
 - name: Install puppet via apt
   apt: pkg={{ item }} state={{ puppet_package_state }} update_cache=yes
   with_items:
-    - {{ puppet_package_list }}
+    - "{{ puppet_package_list }}"
   when: ansible_os_family == 'Debian'
   tags:
     - install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
----
 - name: Install PuppetLabs release RPM for Fedora or EL derivatives
   yum:name="{{ item }}.noarch.rpm" state={{ puppet_release_package_state }}
   with_item:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   template: src=repo.j2 dest=/etc/apt.sources.d/puppetlabs.source owner=root group=root mode=0644
   apt: pkg=puppet state={{ item }} update_cache=yes
   with_items:
-    - "{{ puppet_release_rpm_baseurl }}/puppetlabs-release-{{ ansible_distribution_release }}"
+    - "{{ puppet_release_rpm_baseurl }}/puppetlabs-release-{{ ansible_distribution_release }}.deb"
   when: ansible_os_family == 'Debian'
   tags:
     - repo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install PuppetLabs release RPM for Fedora or EL derivatives
   yum:name="{{ item }}.noarch.rpm" state={{ puppet_release_package_state }}
-  with_item:
+  with_items:
     - "{{ puppet_release_rpm_baseurl }}/puppetlabs-release-{% if ansible_distribution == 'Fedora' %}fedora{% else %}el{% endif %}-{{ ansible_distribution_version.split('.')[0] }}"
   when: ansible_os_family == 'RedHat'
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,22 @@
     - install
     - service
 
+# The puppet agent return codes are interesting
+#
+# 0 = no changes
+# 1 = puppet run already in progress
+# 2 = changes
+# 4 = failures during execution
+# 6 = changes and failures
+#
+# https://github.com/ansible/ansible/blob/devel/test/playbook-failed_when.yml
+# https://github.com/ansible/ansible/blob/devel/test/playbook-changed_when.yml
+#
+# Credit to Alex Schultz github.com/mwhahaha
+
 - name: Force run of puppet agent
   command: /usr/bin/puppet agent apply --test --server={{ puppet_master }} --environment={{ puppet_environment }} --waitforcert {{ puppet_waitforcert }}
+  register: puppet_agent_apply
+  failed_when: not puppet_agent_apply.rc in [0, 2]
   tags:
     - run

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,6 @@
     - service
 
 - name: Force run of puppet agent
-  command: /usr/bin/puppet agent apply --test --server={{ puppet_master }} --environment={{ puppet_environment }}
+  command: /usr/bin/puppet agent apply --test --server={{ puppet_master }} --environment={{ puppet_environment }} --waitforcert {{ puppet_waitforcert }}
   tags:
     - run

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,11 +37,19 @@
     - install
     - packages
 
+- name: Disable puppet service
+  service: name=puppet enabled=no state=stopped
+  tags:
+    - install
+    - service
+    - disable
+
 - name: Enable puppet service
   service: name=puppet enabled=yes state=started
   tags:
     - install
     - service
+    - enable
 
 # The puppet agent return codes are interesting
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
 # Credit to Alex Schultz github.com/mwhahaha
 
 - name: Force run of puppet agent
-  command: /usr/bin/puppet agent apply --test --server={{ puppet_master }} --environment={{ puppet_environment }} --waitforcert {{ puppet_waitforcert }}
+  command: /usr/bin/puppet agent apply --test --color=false --server={{ puppet_master }} --environment={{ puppet_environment }} --waitforcert {{ puppet_waitforcert }}
   register: puppet_agent_apply
   failed_when: not puppet_agent_apply.rc in [0, 2]
   tags:

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
 export ANSIBLE_ROLES_PATH=$(dirname $(pwd))
 echo $ANSIBLE_ROLES_PATH
-ansible-playbook -i hosts puppet.yml -vvv
+ansible-playbook -i hosts puppet.yml -vvv --ask-sudo-pass

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+export ANSIBLE_ROLES_PATH=$(dirname $(pwd))
+echo $ANSIBLE_ROLES_PATH
+ansible-playbook -i hosts puppet.yml -vvv


### PR DESCRIPTION
Addresses Issue #1
- Add all(?) Debian/Ubuntu version support
- Add Fedora/EL support
- Add following functions:
  - Install/Enable puppetlabs repo (apt or yum platform dependant)
  - Enable puppet agent service
  - Manual run of puppet agent with server and environment defined (runs with short waitforcert, so depending on environment may require second run)

TODO:
- [ ] Verify
  - [ ] Debian
  - [ ] Ubuntu
  - [ ] Fedora
  - [ ] RHEL
- [ ] Update README
